### PR TITLE
#193 불필요한 Serializable 인터페이스 구현 제거

### DIFF
--- a/core/src/com/mygdx/assets/Assets.java
+++ b/core/src/com/mygdx/assets/Assets.java
@@ -8,8 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.badlogic.gdx.Gdx;
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.JsonStringFile;
+import com.mygdx.util.JsonParser;
 
 /**
  * 각종 리소스들을 관리해주는 assets 클래스, Stage및 Screen에 필요한 요소들을 전달해준다.

--- a/core/src/com/mygdx/assets/AtlasUiAssets.java
+++ b/core/src/com/mygdx/assets/AtlasUiAssets.java
@@ -6,9 +6,9 @@ import java.util.Map;
 
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.AtlasUiFile;
 import com.mygdx.model.JsonStringFile;
+import com.mygdx.util.JsonParser;
 
 public class AtlasUiAssets implements FileAssetsInitializable {
 	public Map<String, TextureRegionDrawable> atlasUiMap = new HashMap<String, TextureRegionDrawable>();

--- a/core/src/com/mygdx/assets/MusicAssets.java
+++ b/core/src/com/mygdx/assets/MusicAssets.java
@@ -7,9 +7,9 @@ import java.util.Map.Entry;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.utils.Json;
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.JsonStringFile;
 import com.mygdx.model.MusicFile;
+import com.mygdx.util.JsonParser;
 
 public class MusicAssets implements FileAssetsInitializable {
 	private Map<String, Music> musicMap = new HashMap<>();

--- a/core/src/com/mygdx/assets/StaticAssets.java
+++ b/core/src/com/mygdx/assets/StaticAssets.java
@@ -14,10 +14,10 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.FrameSheet;
 import com.mygdx.model.JsonStringFile;
 import com.mygdx.model.TextureFile;
+import com.mygdx.util.JsonParser;
 import com.uwsoft.editor.renderer.resources.ResourceManager;
 
 public class StaticAssets {

--- a/core/src/com/mygdx/assets/UnitAssets.java
+++ b/core/src/com/mygdx/assets/UnitAssets.java
@@ -3,10 +3,10 @@ package com.mygdx.assets;
 import java.util.Map;
 
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.Hero;
 import com.mygdx.model.Monster;
 import com.mygdx.model.NPC;
+import com.mygdx.util.JsonParser;
 
 public class UnitAssets implements JsonAssetsInitializable {
 	private Map<String, Hero> heroMap;

--- a/core/src/com/mygdx/assets/WorldMapAssets.java
+++ b/core/src/com/mygdx/assets/WorldMapAssets.java
@@ -3,8 +3,8 @@ package com.mygdx.assets;
 import java.util.Map;
 
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.WorldNode;
+import com.mygdx.util.JsonParser;
 
 public class WorldMapAssets implements JsonAssetsInitializable {
 	private Map<String, WorldNode> worldNodeInfoMap;

--- a/core/src/com/mygdx/assets/WorldNodeAssets.java
+++ b/core/src/com/mygdx/assets/WorldNodeAssets.java
@@ -3,8 +3,8 @@ package com.mygdx.assets;
 import java.util.Map;
 
 import com.mygdx.enums.JsonEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.Village;
+import com.mygdx.util.JsonParser;
 
 public class WorldNodeAssets implements JsonAssetsInitializable {
 	public Map<String, Village> villageMap;

--- a/core/src/com/mygdx/model/Building.java
+++ b/core/src/com/mygdx/model/Building.java
@@ -1,11 +1,7 @@
 package com.mygdx.model;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import com.badlogic.gdx.utils.Json;
-import com.badlogic.gdx.utils.Json.Serializable;
-import com.badlogic.gdx.utils.JsonValue;
 import com.mygdx.enums.BuildingTypeEnum;
 
 /**
@@ -14,7 +10,7 @@ import com.mygdx.enums.BuildingTypeEnum;
  * @author Velmont
  *
  */
-public class Building implements Serializable {
+public class Building {
 	private String buildingName;
 	private BuildingTypeEnum buildingType;
 	private String buildingPath;
@@ -51,22 +47,6 @@ public class Building implements Serializable {
 
 	public void setBuildingNpc(List<String> buildingNpc) {
 		this.buildingNpc = buildingNpc;
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public void read(Json json, JsonValue jsonData) {
-		buildingName = json.readValue("buildingName", String.class, jsonData);
-		buildingType = json.readValue("buildingType", BuildingTypeEnum.class,
-				jsonData);
-		buildingPath = json.readValue("buildingPath", String.class, jsonData);
-		buildingNpc = json.readValue("buildingNpc", ArrayList.class,
-				String.class, jsonData);
-		sceneName = json.readValue("sceneName", String.class, jsonData);
-	}
-
-	@Override
-	public void write(Json json) {
 	}
 
 	public String getSceneName() {

--- a/core/src/com/mygdx/model/Connection.java
+++ b/core/src/com/mygdx/model/Connection.java
@@ -1,15 +1,10 @@
 package com.mygdx.model;
 
 import java.util.ArrayList;
-import java.util.List;
 
-import com.badlogic.gdx.utils.Json;
-import com.badlogic.gdx.utils.Json.Serializable;
-import com.badlogic.gdx.utils.JsonValue;
-
-public class Connection implements Serializable {
+public class Connection {
 	private int roadLength;
-	private List<String> roadMonster;
+	private ArrayList<String> roadMonster;
 	private String arrowName;
 
 	public int getroadLength() {
@@ -20,24 +15,11 @@ public class Connection implements Serializable {
 		this.roadLength = roadLength;
 	}
 
-	@Override
-	public void write(Json json) {
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public void read(Json json, JsonValue jsonData) {
-		roadLength = json.readValue("roadLength", Integer.class, jsonData);
-		roadMonster = json.readValue("roadMonster", ArrayList.class,
-				String.class, jsonData);
-		arrowName = json.readValue("arrowName", String.class, jsonData);
-	}
-
-	public List<String> getRoadMonster() {
+	public ArrayList<String> getRoadMonster() {
 		return roadMonster;
 	}
 
-	public void setRoadMonster(List<String> roadMonster) {
+	public void setRoadMonster(ArrayList<String> roadMonster) {
 		this.roadMonster = roadMonster;
 	}
 

--- a/core/src/com/mygdx/model/EventElement.java
+++ b/core/src/com/mygdx/model/EventElement.java
@@ -1,10 +1,11 @@
 package com.mygdx.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class EventElement {
 	protected String name;
-	protected List<Event> events;
+	protected ArrayList<Event> events;
 
 	public String getName() {
 		return name;
@@ -14,7 +15,7 @@ public class EventElement {
 		this.name = name;
 	}
 
-	public void setEvents(List<Event> events) {
+	public void setEvents(ArrayList<Event> events) {
 		this.events = events;
 	}
 

--- a/core/src/com/mygdx/model/Village.java
+++ b/core/src/com/mygdx/model/Village.java
@@ -1,15 +1,10 @@
 package com.mygdx.model;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.HashMap;
 
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.utils.Json;
-import com.badlogic.gdx.utils.Json.Serializable;
-import com.badlogic.gdx.utils.JsonValue;
 import com.mygdx.enums.TextureEnum;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.manager.TextureManager;
 
 /**
@@ -18,12 +13,12 @@ import com.mygdx.manager.TextureManager;
  * @author Velmont
  *
  */
-public class Village implements Serializable {
+public class Village {
 	private String villageName;
 	private String backgroundPath;
 	private String sceneName;
-	private List<String> villageNpc;
-	private Map<String, Building> building;
+	private ArrayList<String> villageNpc;
+	private HashMap<String, Building> building;
 
 	public String getVillageName() {
 		return villageName;
@@ -43,37 +38,20 @@ public class Village implements Serializable {
 				TextureEnum.BACKGROUND_DOWN);
 	}
 
-	public List<String> getVillageNpc() {
+	public ArrayList<String> getVillageNpc() {
 		return villageNpc;
 	}
 
-	public void setVillageNpc(List<String> villageNpc) {
+	public void setVillageNpc(ArrayList<String> villageNpc) {
 		this.villageNpc = villageNpc;
 	}
 
-	public Map<String, Building> getBuilding() {
+	public HashMap<String, Building> getBuilding() {
 		return building;
 	}
 
-	public void setBuilding(Map<String, Building> building) {
+	public void setBuilding(HashMap<String, Building> building) {
 		this.building = building;
-	}
-
-	@Override
-	public void write(Json json) {
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public void read(Json json, JsonValue jsonData) {
-		villageName = json.readValue("villageName", String.class, jsonData);
-		backgroundPath = json.readValue("backgroundPath", String.class,
-				jsonData);
-		villageNpc = json.readValue("villageNpc", ArrayList.class,
-				String.class, jsonData);
-		building = JsonParser.parseMap(Building.class, jsonData.get("building")
-				.toString());
-		sceneName = json.readValue("sceneName", String.class, jsonData);
 	}
 
 	public String getBackgroundPath() {

--- a/core/src/com/mygdx/model/WorldNode.java
+++ b/core/src/com/mygdx/model/WorldNode.java
@@ -1,22 +1,18 @@
 package com.mygdx.model;
 
+import java.util.HashMap;
 import java.util.Map;
 
-import com.badlogic.gdx.utils.Json;
-import com.badlogic.gdx.utils.Json.Serializable;
-import com.badlogic.gdx.utils.JsonValue;
-import com.mygdx.manager.JsonParser;
-
-public class WorldNode implements Serializable {
+public class WorldNode {
 	private String nodeName;
 	private String type;
-	private Map<String, Connection> connection;
+	private HashMap<String, Connection> connection;
 
 	public Map<String, Connection> getConnection() {
 		return connection;
 	}
 
-	public void setConnection(Map<String, Connection> connection) {
+	public void setConnection(HashMap<String, Connection> connection) {
 		this.connection = connection;
 	}
 
@@ -34,17 +30,5 @@ public class WorldNode implements Serializable {
 
 	public void setType(String type) {
 		this.type = type;
-	}
-
-	@Override
-	public void write(Json json) {
-	}
-
-	@Override
-	public void read(Json json, JsonValue jsonData) {
-		nodeName = json.readValue("nodeName", String.class, jsonData);
-		type = json.readValue("type", String.class, jsonData);
-		connection = JsonParser.parseMap(Connection.class,
-				jsonData.get("connection").toString());
 	}
 }

--- a/core/src/com/mygdx/util/JsonParser.java
+++ b/core/src/com/mygdx/util/JsonParser.java
@@ -1,9 +1,7 @@
-package com.mygdx.manager;
+package com.mygdx.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonValue;
@@ -12,11 +10,12 @@ public class JsonParser {
 	private static final Json JSON = new Json();
 
 	@SuppressWarnings("unchecked")
-	public static <T> Map<String, T> parseMap(Class<T> clazz, String jsonString) {
-		Map<String, JsonValue> parsedMap = JSON.fromJson(HashMap.class,
+	public static <T> HashMap<String, T> parseMap(Class<T> clazz,
+			String jsonString) {
+		HashMap<String, JsonValue> parsedMap = JSON.fromJson(HashMap.class,
 				jsonString);
 
-		Map<String, T> result = new HashMap<String, T>();
+		HashMap<String, T> result = new HashMap<String, T>();
 
 		for (String key : parsedMap.keySet())
 			result.put(key, JSON.readValue(clazz, parsedMap.get(key)));
@@ -25,9 +24,10 @@ public class JsonParser {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T> List<T> parseList(Class<T> clazz, String jsonString) {
-		List<JsonValue> parsedList = JSON.fromJson(ArrayList.class, jsonString);
-		List<T> result = new ArrayList<T>();
+	public static <T> ArrayList<T> parseList(Class<T> clazz, String jsonString) {
+		ArrayList<JsonValue> parsedList = JSON.fromJson(ArrayList.class,
+				jsonString);
+		ArrayList<T> result = new ArrayList<T>();
 
 		for (JsonValue jsonValue : parsedList)
 			result.add(JSON.readValue(clazz, jsonValue));

--- a/core/src/com/mygdx/util/LibgdxUtils.java
+++ b/core/src/com/mygdx/util/LibgdxUtils.java
@@ -19,7 +19,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.mygdx.manager;
+package com.mygdx.util;
 
 import java.util.Random;
 

--- a/core/test/com/mygdx/test/NPCJsonModelingTest.java
+++ b/core/test/com/mygdx/test/NPCJsonModelingTest.java
@@ -8,8 +8,8 @@ import java.util.Scanner;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.mygdx.assets.Assets;
-import com.mygdx.manager.JsonParser;
 import com.mygdx.model.NPC;
+import com.mygdx.util.JsonParser;
 
 public class NPCJsonModelingTest {
 	@Autowired


### PR DESCRIPTION
모델 클래스의 필드 타입이 Map -> HashMap, List -> ArrayList
이런식으로 구체적으로 제시될경우 fromJson으로 가져올때 Serializable 
구현이 더 이상 필요하지 않습니다.

JsonParser는 util 패키지로 이동시켰습니다.
